### PR TITLE
Remove dead code that check case when `syslog` returns false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 under development
 
-- no changes in this release.
+- Enh #45: Remove dead code that check case when `syslog` returns false (@vjik)
 
 ## 2.0.0 February 17, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 under development
 
-- Enh #45: Remove dead code that check case when `syslog` returns false (@vjik)
+- Enh #45: Remove dead code that check case when `syslog()` returns false (@vjik)
 
 ## 2.0.0 February 17, 2023
 

--- a/src/SyslogTarget.php
+++ b/src/SyslogTarget.php
@@ -72,9 +72,7 @@ final class SyslogTarget extends Target
         openlog($this->identity, $this->options, $this->facility);
 
         foreach ($this->getMessages() as $key => $message) {
-            if (syslog(self::SYSLOG_LEVELS[$message->level()], $formattedMessages[$key]) === false) {
-                throw new RuntimeException('Unable to export log through system log.');
-            }
+            syslog(self::SYSLOG_LEVELS[$message->level()], $formattedMessages[$key]);
         }
 
         closelog();

--- a/tests/SyslogTargetTest.php
+++ b/tests/SyslogTargetTest.php
@@ -79,20 +79,6 @@ final class SyslogTargetTest extends TestCase
         $syslogTarget->collect($messages, true);
     }
 
-    public function testFailedExport(): void
-    {
-        $syslogTarget = new SyslogTarget('identity-string');
-
-        $this
-            ->getFunctionMock('Yiisoft\Log\Target\Syslog', 'syslog')
-            ->expects($this->once())
-            ->willReturn(false)
-        ;
-
-        $this->expectException(RuntimeException::class);
-        $syslogTarget->collect([new Message(LogLevel::INFO, 'test', ['category' => 'app'])], true);
-    }
-
     public function testSetFormatAndSetPrefixAndExport(): void
     {
         $syslogTarget = new SyslogTarget('identity-string');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

`syslog()` always returns false ([docs](https://www.php.net/manual/en/function.syslog.php#refsect1-function.syslog-returnvalues))
